### PR TITLE
Support custom matchers in deep comparison

### DIFF
--- a/expectacle.js
+++ b/expectacle.js
@@ -924,15 +924,15 @@
    * E.g. expect(obj).toBeLike({x: true, y: false, z: expect.type.string()});
    *
    * @type {Object}
-   * @property {object} any Matches anything that is not undefined
-   * @property {object} string Matches any string
-   * @property {object} number Matches any number
-   * @property {object} bool Matches any boolean
-   * @property {object} func Matches any function
-   * @property {object} obj Matches any object
-   * @property {object} arr Matches any array
-   * @property {object} date Matches any date
-   * @property {object} regexp Matches any regular expression
+   * @property {function} any Matches anything that is not undefined
+   * @property {function} string Matches any string
+   * @property {function} number Matches any number
+   * @property {function} bool Matches any boolean
+   * @property {function} func Matches any function
+   * @property {function} obj Matches any object
+   * @property {function} arr Matches any array
+   * @property {function} date Matches any date
+   * @property {function} regexp Matches any regular expression
    */
   expect.type = {
     any: createTypeMatcher(),

--- a/test/expectacle.js
+++ b/test/expectacle.js
@@ -133,9 +133,17 @@ describe('Expectacle', function() {
           done();
         }
       });
+      it('should fail if the two objects are not strictly like each other', function(done) {
+        try {
+          expect({x: true, y: '', z: {a: 1, b: 2}}).toBeLike({x: 1, y: 0, z: {a: true, b: 2}});
+          done(new Error('expect.toBeLike should have failed'));
+        } catch(e) {
+          done();
+        }
+      });
       it('should pass if the two objects are like each other', function(done) {
         try {
-          expect({x: true, y: ''}).toBeLike({x: 1, y: 0}); // sic
+          expect({x: true, y: [1, 2], z: {a: '', b: 2}}).toBeLike({x: true, y: [1, 2], z: {a: '', b: 2}});
           done();
         } catch(e) {
           done(new Error(e));

--- a/test/expectacle.js
+++ b/test/expectacle.js
@@ -124,6 +124,94 @@ describe('Expectacle', function() {
 
     });
 
+    describe('toBeLike', function() {
+      it('should fail if the two objects are not like each other', function(done) {
+        try {
+          expect({x: true}).toBeLike({x: false});
+          done(new Error('similar objects should match'));
+        } catch(e) {
+          done();
+        }
+      });
+      it('should pass if the two objects are like each other', function(done) {
+        try {
+          expect({x: true, y: ''}).toBeLike({x: 1, y: 0}); // sic
+          done();
+        } catch(e) {
+          done(new Error(e));
+        }
+      });
+      it('should fail if the expect.type matchers are not matched', function(done) {
+        try {
+          expect({}).toBeLike({x: expect.type.any});
+          done(new Error('expect.type.any should not match undefined'));
+        } catch(e) {
+          done();
+        }
+      });
+      it('should consider an object to match if the expect.type placeholders are satisfied', function(done) {
+        var type = expect.type;
+        try {
+          expect({
+            deep: {
+              a: [],
+              b: true,
+              c: {},
+              d: new Date(),
+              r: /pattern/g,
+              x: 123,
+              y: 'hello',
+              z: function() {}
+            },
+            a: '',
+            b: 123,
+            c: []
+          }).toBeLike({
+            deep: {
+              a: type.arr(),
+              b: type.bool(),
+              c: type.obj(),
+              d: type.date(),
+              r: type.regexp(),
+              x: type.number(),
+              y: type.string(),
+              z: type.func()
+            },
+            a: type.string(),
+            b: type.number(),
+            c: type.arr()
+          });
+          done();
+        } catch(e) {
+          done(new Error(e));
+        }
+      });
+      it('should fail if expect.type.any is used for an undefined property', function(done) {
+        try {
+          expect({}).toBeLike({a: expect.type.any()});
+          done(new Error('undefined should not match expect.type.any'));
+        } catch(e) {
+          done();
+        }
+      });
+      it('should fail if expect.type.bool is used for a number', function(done) {
+        try {
+          expect({a: 1}).toBeLike({a: expect.type.bool()});
+          done(new Error('a number should not match expect.type.bool'));
+        } catch(e) {
+          done();
+        }
+      });
+      it('should fail if expect.type.obj is used for an array', function(done) {
+        try {
+          expect({a: []}).toBeLike({a: expect.type.obj()});
+          done(new Error('an array should not match expect.type.obj'));
+        } catch(e) {
+          done();
+        }
+      });
+    });
+
     describe('toBeAnInstanceOf', function() {
 
       it('should throw an error if called without a function argument.', function(done) {


### PR DESCRIPTION
If a property in the expected object behaves like a custom matcher (by having a method called matchExpected), then matching is performed by calling the matchExpected method with the actual value as argument.

Built in custom matchers to validate types of properties instead of their values, inspired by sinon.match.<type>:

* expect.type.any() - Matches anything that is not undefined
* expect.type.string() - Matches any string
* expect.type.number() - Matches any number
* expect.type.bool() - Matches any boolean
* expect.type.func() - Matches any function
* expect.type.obj() - Matches any object
* expect.type.arr() - Matches any array
* expect.type.date() - Matches any date
* expect.type.regexp() - Matches any regular expression

(These are exposed as functions to prevent accidental typos - e.g. if you in your testcase had typed `expect.type.regex` instead of `expect.type.regexp` you would have a false pass if the actual value was `undefined`, but since you now must invoke `expect.type.regexp()` you should early on catch a typo like `expect.type.regex()` and thereby avoid the false pass.)