### PR TITLE
Support diffs when used with Mocha

### DIFF
--- a/expectacle.js
+++ b/expectacle.js
@@ -425,6 +425,7 @@
     this.operator = options.operator;
     this.expected = options.expected;
     this.received = options.received;
+    this.actual = options.received;
     this.description = options.description;
     this.message = options.message || this.toString();
     if (Error.captureStackTrace) {


### PR DESCRIPTION
Alias the `err.received` property as `err.actual`. This will cause Mocha to display the assertion error with a diff so that it's easier to see how the result differs from the expected output.

### From https://mochajs.org/#diffs

> Mocha supports the `err.expected` and `err.actual` properties of any thrown `AssertionError`s from an assertion library. Mocha will attempt to display the difference between what was expected, and what the assertion actually saw.