### PR TITLE
feat: add expect.assert

### DIFF
--- a/expectacle.d.ts
+++ b/expectacle.d.ts
@@ -48,7 +48,7 @@ declare namespace expect {
 
     toBeLike(v: any): Chainer;
 
-    toHaveShape(v: { [name: string]: Shape } | Shape): Chainer;
+    toHaveShape(v: {[name: string]: Shape} | Shape): Chainer;
 
     toThrow(v: any): Chainer;
     toMatch(v: any): Chainer;
@@ -104,6 +104,28 @@ declare namespace expect {
   ): expect.PromisedExpectation<T>;
   export function typeOf(value: any): string;
   export function fail(opt_message?: string): void;
+
+  /**
+   * Asserts that a condition is met. If the condition is not met, an
+   * ExpectationError is thrown.
+   *
+   * @example
+   *
+   * ```ts
+   * expect.assert(1 === 1);
+   *
+   * let value = getValueOfUnknownType();
+   * expect.assert(typeof value === 'string', 'Expected a string value'); // The type of value is now narrowed to string.
+   * expect(value.startsWith('abc')).toBe(true); // Other assertions can now be made on value as a string.
+   * ```
+   *
+   * @param condition - The condition to test.
+   * @param opt_message - An optional message to include in the error.
+   */
+  export function assert(
+    condition: any,
+    opt_message?: string
+  ): asserts condition;
   export function addMatcher(name: string, matcher: any): void;
-  export function addMatchers(matchers: { [name: string]: any }): void;
+  export function addMatchers(matchers: {[name: string]: any}): void;
 }

--- a/expectacle.js
+++ b/expectacle.js
@@ -1285,6 +1285,16 @@
     });
   };
 
+  expect.assert = function (condition, message) {
+    if (!condition) {
+      throw new ExpectationError({
+        message:
+          message || 'The condition passed to expect.assert was not met.',
+        stackFn: expect.assert,
+      });
+    }
+  };
+
   /**
    * Adds a matcher.
    *

--- a/test/expectacle.js
+++ b/test/expectacle.js
@@ -50,6 +50,45 @@ describe('Expectacle', function () {
     });
   });
 
+  describe('Function: expect.assert()', function () {
+    it('should not throw an error if the condition is met.', function () {
+      expect.assert(true);
+      expect.assert(1);
+      expect.assert('hello');
+    });
+
+    it('should throw a new ExpectationError if the condition is not met.', function () {
+      let error = null;
+      try {
+        expect.assert(false);
+      } catch (e) {
+        error = e;
+      }
+      if (error === null) {
+        throw new Error('expect.assert did not throw an error.');
+      }
+      if (error.name !== 'ExpectationError') {
+        throw new Error('expect.assert did not throw an ExpectationError.');
+      }
+    });
+
+    it('should use the optional message argument as the error message.', function () {
+      const message = 'This is an error message.';
+      let error = null;
+      try {
+        expect.assert(0, message);
+      } catch (e) {
+        error = e;
+      }
+      if (error === null) {
+        throw new Error('expect.assert did not throw an error.');
+      }
+      if (error.message !== message) {
+        throw new Error('expect.assert did not use the message argument.');
+      }
+    });
+  });
+
   describe('Default Matchers', function () {
     describe('toBe Matcher', function () {
       it('should strictly match value to the expected value.', function () {


### PR DESCRIPTION
Add a simple assertion function.

Although an assert function may not be as expressive as the `expect` function, it's sometimes very useful to narrow down the type before doing other tests on a value.

```ts
expect.assert(1 === 1);

let value = getValueOfUnknownType();
expect.assert(typeof value === 'string', 'Expected a string value');
// The type of value is now narrowed to string.
expect(value.startsWith('abc')).toBe(true);
// Other assertions can now be made on value as a string.
```
