### PR TITLE
expect.fail returns the never type

### DIFF
--- a/expectacle.d.ts
+++ b/expectacle.d.ts
@@ -103,7 +103,7 @@ declare namespace expect {
     description?: string
   ): expect.PromisedExpectation<T>;
   export function typeOf(value: any): string;
-  export function fail(opt_message?: string): void;
+  export function fail(opt_message?: string): never;
   export function addMatcher(name: string, matcher: any): void;
   export function addMatchers(matchers: { [name: string]: any }): void;
 }


### PR DESCRIPTION
This function always throws so the correct return type is `never`.

This also enables type narrowing in typescript:

```ts
const value: string | null = getValue();

if (value === null) {
  expect.fail('Expected a string');
}

// typescript has now narrowed the type down to `string`
value.toUpperCase();
```